### PR TITLE
Use puppet to find out if certificate is available

### DIFF
--- a/scripts/12_generate_puppetmaster_keys.sh
+++ b/scripts/12_generate_puppetmaster_keys.sh
@@ -12,6 +12,6 @@ test -z "$PUPPETMASTER_DNS_NAMES" && \
     export PUPPETMASTER_DNS_NAMES="$hostname,$fqdn,puppet,puppet.$domain"
 
 # if there's no certificate yet, generate it
-if [ ! -f "/var/lib/puppet/ssl/certs/$fqdn.pem" ]; then 
+if [ -z "$(puppet cert list -a 2> /dev/null | grep \"$fqdn\")" ]; then 
     puppet cert generate --path "$PATH" --dns_alt_names "$PUPPETMASTER_DNS_NAMES" $fqdn
 fi


### PR DESCRIPTION
My certificates are stored in /etc/puppet/ssl/cert, so the original check does not work.

Using puppet itself to check if a certificate is available (and can be used/found by puppet) seems more robust (for changing locations).