### PR TITLE
Passenger 5.0.22 now filtering header with underscore

### DIFF
--- a/scripts/11_generate_nginx_site.rb
+++ b/scripts/11_generate_nginx_site.rb
@@ -23,8 +23,8 @@ server {
     server_name #{puppetmaster_dns_names};
 
     passenger_enabled          on;
-    passenger_set_header       X_CLIENT_S_DN $ssl_client_s_dn; 
-    passenger_set_header       X_CLIENT_VERIFY $ssl_client_verify; 
+    passenger_set_header       x-client-s-dn $ssl_client_s_dn; 
+    passenger_set_header       x-client-verify $ssl_client_verify; 
 
     access_log                 /var/log/nginx/puppet_access.log;
     error_log                  /var/log/nginx/puppet_error.log;


### PR DESCRIPTION
Very annoying "bug" because https://blog.phusion.nl/2015/12/07/cve-2015-7519/
SSL header was not set at all and any agent cannot connect to master.